### PR TITLE
Issue #2 fix

### DIFF
--- a/YT-playlist-cleaner.js
+++ b/YT-playlist-cleaner.js
@@ -43,6 +43,14 @@ let state = {
   }
 };
 
+// Fix TrustedHTML assignment error in chrome
+// Disable checking of strings passed to innerHTML/createHTML
+if (window.trustedTypes && window.trustedTypes.createPolicy) {
+  window.trustedTypes.createPolicy('default', {
+    createHTML: (string, sink) => string
+  });
+}
+
 // Check if it's first time and show welcome message
 if (!localStorage.getItem('ytPlaylistCleanerFirstTime')) {
   window.addEventListener('load', () => {


### PR DESCRIPTION
Fixes a TrustedHTML assignment error in сhrome by setting the trustedTypes policy to pass through any string from innerHTML. 
This should work only in and for chrome.

